### PR TITLE
Update help output based on 1.0.2 actual output

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,8 @@ Options:
   -?|-h|--help  Show help information
 
 Commands:
-  get           Downloads the provided release version & platform.
+  download      Downloads the provided release version & platform.
   list          Lists all installed .NET Core SDKs
-  releases      Lists all available releases of .NET Core SDKs
   set           Switches to the specified .NET Core SDK version
 
 Run 'dotnet-sdk [command] --help' for more information about a command.


### PR DESCRIPTION
On version 1.0.2 if you do `dotnet sdk --help` you get something different than what's in the README. This just brings it up to date.