### PR TITLE
Unify build and publish .NET SDK versions.

### DIFF
--- a/.github/workflows/Publish to Nuget.yml
+++ b/.github/workflows/Publish to Nuget.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 2.2.401
+          dotnet-version: 3.1.403
 
       - name: Build and publish
         run: |

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "rollForward": "latestFeature",
+    "version": "3.1.403"
+  }
+}


### PR DESCRIPTION
It was possible to build the project using one .NET SDK version then have the publish to NuGet run under a different/fixed version. This unifies the two .NET SDK versions so it's consistent. Still targeting `netcoreapp2.1`, but building under SDK 3.1 LTS.