### PR TITLE
Fix listing of installed SDKs when location contains a space

### DIFF
--- a/src/DotNetSdkHelpers/Commands/List.cs
+++ b/src/DotNetSdkHelpers/Commands/List.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -49,7 +49,7 @@ namespace DotNetSdkHelpers.Commands
             Console.WriteLine(string.Join(
                 Environment.NewLine,
                 sdks
-                    .Select(sdk => $"{sdk.Version.PadRight(longestName)} {sdk.Location}")));
+                    .Select(sdk => $"{sdk.Version.PadRight(longestName)} [{sdk.Location}]")));
         }
 
         public async Task ListAvailable()

--- a/src/DotNetSdkHelpers/Helpers.cs
+++ b/src/DotNetSdkHelpers/Helpers.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -38,8 +38,10 @@ namespace DotNetSdkHelpers
                 .Split(Environment.NewLine)
                 .Select(sdk =>
                 {
-                    var parts = sdk.Split(' ');
-                    return new InstalledSdk(parts[0], parts[1]);
+                    var splitIndex = sdk.IndexOf(' ');
+                    var version = sdk.Substring(0, splitIndex);
+                    var location = sdk.Substring(splitIndex).Trim().Trim('[', ']');
+                    return new InstalledSdk(version, location);
                 })
                 .ToList();
     }


### PR DESCRIPTION
The `dotnet sdk list` command was not properly displaying the location of an installed SDK when the path contained a space (e.g. the default location on windows at `C:\Program Files\dotnet\sdk`).

With this change, the location should not be display correctly.

The value of the location property will now also no longer include the opening an closing brackets and the brackets are added when printing the location to the console instead.