### PR TITLE
Added package metadata and target frameworks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
       "cwd": "${workspaceFolder}/src/DotNetSdkHelpers",
       "name": ".NET Core Launch (console)",
       "preLaunchTask": "build",
-      "program": "${workspaceFolder}/src/DotNetSdkHelpers/bin/Debug/netcoreapp2.1/DotNetSdkHelpers.dll",
+      "program": "${workspaceFolder}/src/DotNetSdkHelpers/bin/Debug/net5.0/DotNetSdkHelpers.dll",
       "request": "launch",
       "stopAtEntry": false,
       "type": "coreclr"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "3.1.403"
+    "version": "5.0.200"
   }
 }

--- a/src/DotNetSdkHelpers/DotNetSdkHelpers.csproj
+++ b/src/DotNetSdkHelpers/DotNetSdkHelpers.csproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
 </Project>

--- a/src/DotNetSdkHelpers/DotNetSdkHelpers.csproj
+++ b/src/DotNetSdkHelpers/DotNetSdkHelpers.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-sdk</ToolCommandName>
     <LangVersion>9.0</LangVersion>

--- a/src/DotNetSdkHelpers/DotNetSdkHelpers.csproj
+++ b/src/DotNetSdkHelpers/DotNetSdkHelpers.csproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
+    <ContinuousIntegrationBuild>$(CI)</ContinuousIntegrationBuild>
     <ToolCommandName>dotnet-sdk</ToolCommandName>
     <LangVersion>9.0</LangVersion>
     <Version>2.0.1</Version>

--- a/src/DotNetSdkHelpers/DotNetSdkHelpers.csproj
+++ b/src/DotNetSdkHelpers/DotNetSdkHelpers.csproj
@@ -7,7 +7,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <ToolCommandName>dotnet-sdk</ToolCommandName>
     <LangVersion>9.0</LangVersion>
-    <Version>2.0.1</Version>
+    <Version>2.1.0</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/jonstodle/DotNetSdkHelpers</RepositoryUrl>
     <Description>Manage the .NET SDK versions you have installed and get new ones, all with a dotnet CLI tool.</Description>

--- a/src/DotNetSdkHelpers/DotNetSdkHelpers.csproj
+++ b/src/DotNetSdkHelpers/DotNetSdkHelpers.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
     <ContinuousIntegrationBuild>$(CI)</ContinuousIntegrationBuild>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <ToolCommandName>dotnet-sdk</ToolCommandName>
     <LangVersion>9.0</LangVersion>
     <Version>2.0.1</Version>


### PR DESCRIPTION
- Enabled SourceLink for debugging support.
- Updated package metadata so NuGet Package Explorer validates everything out as correct.
- Added more target frameworks so folks with only newer SDKs installed can still use the tool.
- Updated semantic version to 2.1.0 - feature increment due to new SDK support.