### PR TITLE
Add .NET 7, drop .NET 5

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
       "cwd": "${workspaceFolder}/src/DotNetSdkHelpers",
       "name": ".NET Core Launch (console)",
       "preLaunchTask": "build",
-      "program": "${workspaceFolder}/src/DotNetSdkHelpers/bin/Debug/net6.0/DotNetSdkHelpers.dll",
+      "program": "${workspaceFolder}/src/DotNetSdkHelpers/bin/Debug/net7.0/DotNetSdkHelpers.dll",
       "request": "launch",
       "stopAtEntry": false,
       "type": "coreclr"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "6.0.401"
+    "version": "7.0.200"
   }
 }

--- a/src/DotNetSdkHelpers/Commands/List.cs
+++ b/src/DotNetSdkHelpers/Commands/List.cs
@@ -175,7 +175,7 @@ public class List : Command
     /// Metadata class supporting the listing of SDK releases. Aggregates data across
     /// release channels and individual releases within the channels.
     /// </summary>
-    private class ReleaseMeta
+    private sealed class ReleaseMeta
     {
         public SupportPhase? SupportPhase { get; set; }
         public ReleaseType? ReleaseType { get; set; }

--- a/src/DotNetSdkHelpers/DotNetSdkHelpers.csproj
+++ b/src/DotNetSdkHelpers/DotNetSdkHelpers.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
     <ContinuousIntegrationBuild>$(CI)</ContinuousIntegrationBuild>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <ToolCommandName>dotnet-sdk</ToolCommandName>
     <LangVersion>latest</LangVersion>
-    <Version>3.1.0</Version>
+    <Version>4.0.0</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/jonstodle/DotNetSdkHelpers</RepositoryUrl>

--- a/src/DotNetSdkHelpers/DotNetSdkHelpers.csproj
+++ b/src/DotNetSdkHelpers/DotNetSdkHelpers.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
     <ContinuousIntegrationBuild>$(CI)</ContinuousIntegrationBuild>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <ToolCommandName>dotnet-sdk</ToolCommandName>
     <LangVersion>latest</LangVersion>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/jonstodle/DotNetSdkHelpers</RepositoryUrl>

--- a/src/DotNetSdkHelpers/DotNetSdkHelpers.csproj
+++ b/src/DotNetSdkHelpers/DotNetSdkHelpers.csproj
@@ -24,8 +24,8 @@
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.1" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 </Project>

--- a/src/DotNetSdkHelpers/Program.cs
+++ b/src/DotNetSdkHelpers/Program.cs
@@ -7,7 +7,7 @@ namespace DotNetSdkHelpers;
  Subcommand(typeof(Set)),
  Subcommand(typeof(List)),
  Subcommand(typeof(Download))]
-class Program
+internal sealed class Program
 {
     static void Main(string[] args)
     {


### PR DESCRIPTION
- Added .NET 7 target.
- Removed .NET 5 target - .NET 5 is out of service and folks should be upgrading. Targeting that causes a build warning now.
- Upgraded dependencies.
- Semver updated to 4.0.0 for the .NET 5 removal/breaking change.