### PR TITLE
Add BuiltWithDotNet badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DotNetSdkHelpers
 
-[![NuGet](https://img.shields.io/nuget/v/DotNetSdkHelpers)](https://www.nuget.org/packages/DotNetSdkHelpers/)
+[![NuGet](https://img.shields.io/nuget/v/DotNetSdkHelpers)](https://www.nuget.org/packages/DotNetSdkHelpers/) [![BuiltWithDot.Net shield](https://builtwithdot.net/project/415/dotnet-sdk-helpers-cli-tool/badge)](https://builtwithdot.net/project/415/dotnet-sdk-helpers-cli-tool)
 
 A shameless .NET Core CLI tool port of [.NET Core SDK CLI Helpers](https://github.com/faniereynders/dotnet-sdk-helpers)
 


### PR DESCRIPTION
Since this project is listed on BuiltWithDot.Net I've taken the liberty to raise a PR that adds the BuiltWithDot.Net badge for .NET Sdk Helpers to the README.md file. This will help promote .NET Sdk Helpers, BuiltWithDot.Net, all other .NET developers that have projects listed on the site, and the .NET ecosystem in general. If you have any questions or concerns, please let me know. Your help is much appreciated!

Thanks, Corstiaan (creator of BuiltWithDot.Net)

PS If you dont' want to add the badge, that's totally fine. Just close this PR. No hard feelings :-)